### PR TITLE
Update fast-kohya-trainer.ipynb

### DIFF
--- a/fast-kohya-trainer.ipynb
+++ b/fast-kohya-trainer.ipynb
@@ -203,7 +203,7 @@
         "os.makedirs(vae, exist_ok=True)\n",
         "os.makedirs(train_data_dir, exist_ok=True)\n",
         "\n",
-        "def install_dependencies()\n",
+        "def install_dependencies():\n",
         "  !pip -q install --upgrade gdown\n",
         "  !apt -q install liblz4-tool aria2\n",
         "  !pip -q install --upgrade -r requirements.txt\n",


### PR DESCRIPTION
fixed misstype with semicolon